### PR TITLE
fix token display size

### DIFF
--- a/src/sign_msg_auth_token.c
+++ b/src/sign_msg_auth_token.c
@@ -17,7 +17,7 @@ typedef struct {
     uint32_t len;
     uint8_t hash[HASH_LEN];
     uint8_t signature[MESSAGE_SIGNATURE_LEN];
-    char token[AUTH_TOKEN_DISPLAY_MAX_SIZE];
+    char token[AUTH_TOKEN_DISPLAY_MAX_SIZE + 1];
     char auth_token_buffer[AUTH_TOKEN_ENCODED_ORIGIN_MAX_SIZE];
     char auth_origin[AUTH_TOKEN_ENCODED_ORIGIN_MAX_SIZE];
     char auth_ttl[AUTH_TOKEN_ENCODED_TTL_MAX_SIZE];


### PR DESCRIPTION
Inside the `update_token_display_data` function, if the data was too long, `...` were added at the end, and a null terminator `\0` after that. However, the final count passed the size of the `token` variable by 1. 
This PR increases the size of the `token` variable