### PR TITLE
Adjust limits (for STAX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Or this to remove it:
 ```$ make delete```
 
 If you want to check the build process for a specific device:
-- Nano S: `$make load && make BOLOS_SDK=$NANOS_SDK`
-- Nano X `$make load && make BOLOS_SDK=$NANOX_SDK`
-- Stax: `$make load && make BOLOS_SDK=$STAX_SDK`
+- Nano S: `make && BOLOS_SDK=$NANOS_SDK make load`
+- Nano X `make && BOLOS_SDK=$NANOX_SDK make load`
+- Stax: `make && BOLOS_SDK=$STAX_SDK make load`
 
 Reference: https://github.com/LedgerHQ/ledger-app-builder
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -58,7 +58,9 @@ typedef enum { CONTRACT_DATA_ENABLED = true, CONTRACT_DATA_DISABLED = false } co
 #ifdef HAVE_BAGL
 #define MAX_DISPLAY_DATA_SIZE 64UL  // must be multiple of 4
 #else
-#define MAX_DISPLAY_DATA_SIZE 256UL  // must be multiple of 4
+// must be multiple of 4
+// must be <= MAX_VALUE_LEN
+#define MAX_DISPLAY_DATA_SIZE 128UL
 #endif
 #define DATA_SIZE_LEN                      17
 #define MAX_CHAINID_LEN                    4

--- a/src/sign_tx_hash.h
+++ b/src/sign_tx_hash.h
@@ -19,7 +19,7 @@
 #define RELAYER_FIELD           "relayer"
 
 #define MAX_FIELD_LEN 16
-#define MAX_VALUE_LEN 128
+#define MAX_VALUE_LEN 128UL
 
 typedef enum parser_status_e {
     JSON_IDLE,

--- a/src/sign_tx_hash.h
+++ b/src/sign_tx_hash.h
@@ -2,6 +2,7 @@
 #define _SIGN_TX_HASH_H_
 
 #include <stdint.h>
+#include "constants.h"
 
 #define NONCE_FIELD             "nonce"
 #define VALUE_FIELD             "value"
@@ -19,7 +20,7 @@
 #define RELAYER_FIELD           "relayer"
 
 #define MAX_FIELD_LEN 16
-#define MAX_VALUE_LEN 128UL
+#define MAX_VALUE_LEN (MAX_DISPLAY_DATA_SIZE * 2)
 
 typedef enum parser_status_e {
     JSON_IDLE,

--- a/src/sign_tx_hash.h
+++ b/src/sign_tx_hash.h
@@ -2,7 +2,6 @@
 #define _SIGN_TX_HASH_H_
 
 #include <stdint.h>
-#include "constants.h"
 
 #define NONCE_FIELD             "nonce"
 #define VALUE_FIELD             "value"
@@ -20,7 +19,7 @@
 #define RELAYER_FIELD           "relayer"
 
 #define MAX_FIELD_LEN 16
-#define MAX_VALUE_LEN (MAX_DISPLAY_DATA_SIZE * 2)
+#define MAX_VALUE_LEN 128
 
 typedef enum parser_status_e {
     JSON_IDLE,


### PR DESCRIPTION
Allocation of `tx_hash_context.current_value` (bounded by **MAX_VALUE_LEN**):
 - https://github.com/multiversx/mx-ledger-nano/blob/relayed-v3-support/src/sign_tx_hash.h#L40

While `enc_len` is bounded by **MAX_DISPLAY_DATA_SIZE**:
 - https://github.com/multiversx/mx-ledger-nano/blob/relayed-v3-support/src/parse_tx.c#L241

For STAX, `MAX_DISPLAY_DATA_SIZE = 256`, thus ` memmove(encoded, tx_hash_context.current_value, enc_len);` fails to correctly copy the data (destination buffer is too short). This leads to an error when decoding it as _base64_ (within _verify_data_).

For Nano S, `MAX_DISPLAY_DATA_SIZE = 64`, issue not present.

Fix: ensure that `MAX_DISPLAY_DATA_SIZE <= MAX_VALUE_LEN` **on all devices.**